### PR TITLE
Fix code font fallback

### DIFF
--- a/assets/css/jazzy.css.scss
+++ b/assets/css/jazzy.css.scss
@@ -23,7 +23,7 @@ $color_darkblue: #0B293A;
 $color_brightblue: #3A68D8;
 $color_darkblue_lighten: rgba(11, 41, 58, 0.75);
 $keyline_color: rgba(12, 40, 73, 0.08);
-$code_font: Menlo, Bitstream Vera Sans Mono, Monaco, Consolas, monospacee;
+$code_font: Menlo, Bitstream Vera Sans Mono, Monaco, Consolas, monospace;
 
 $purple: #9595D1;
 $blue: #4092C5;


### PR DESCRIPTION
* Fix code font fallback. `monospace` has an additional `e` that makes that option useless in case you don't have any of the previous fonts on your system.