### PR TITLE
meta updates for Swiftype, plus viewport meta

### DIFF
--- a/templates/doc.mustache
+++ b/templates/doc.mustache
@@ -5,6 +5,7 @@
     <link rel="stylesheet" type="text/css" href="{{path_to_root}}css/jazzy.css" />
     <link rel="stylesheet" type="text/css" href="{{path_to_root}}css/highlight.css" />
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="{{path_to_root}}js/jquery.min.js" defer></script>
     <script src="{{path_to_root}}js/jazzy.js" defer></script>
     {{{custom_head}}}

--- a/templates/doc.mustache
+++ b/templates/doc.mustache
@@ -13,8 +13,11 @@
     <script src="{{path_to_root}}js/lunr.min.js" defer></script>
     <script src="{{path_to_root}}js/typeahead.jquery.js" defer></script>
     <script src="{{path_to_root}}js/jazzy.search.js" defer></script>
-    <meta class="swiftype" name="type" data-type="enum" content="{{module_name}} Reference" />
     <meta class="swiftype" name="title" data-type="string" content="{{name}}" />
+    <meta class="swiftype" name="excerpt" data-type="string" content="" />
+    <meta class="swiftype" name="site" data-type="string" content="iOS" />
+    <meta class="swiftype" name="subsite" data-type="string" content="{{kind}}" />
+    <meta class="swiftype" name="contentType" data-type="string" content="reference" />
     {{/disable_search}}
     <style type="text/css">
       .nav-group-name[data-name="{{name}}"] > .small-heading,


### PR DESCRIPTION
This PR update the Swiftype meta tags and adds a viewport meta tag. While we're not sure how the generated docs will be incorporated in the site-wide search (we want to slowly rollout to measure usage so we can allocate time/effort accordingly), but would like to get these pages entered in Swiftype with the attributes we need.

@friedbunny do you know if there's a template var to generate a page description/excerpt? I did a quick search, but haven't found a good resource.